### PR TITLE
[WIP] Draft for supervisor interface and configuration file

### DIFF
--- a/supervisor/conf/config-1.yml
+++ b/supervisor/conf/config-1.yml
@@ -1,0 +1,85 @@
+# Connection details for the OpAMP server.
+opampServer:
+    endpoint: https://localhost:1729
+    tls:
+        # Client-side TLS configuration to connect to the OpAMP server.
+
+# Agent specifies the agent that is being managed by this supervisor. Concretely,
+# the `agent' configuration dictates how to start it and where the configuration
+# file resides. This basic information is necessary for the supervisor to
+# restart the agent on a remote configuration change.
+# `watchdog' and `systemd' config elements are mutually exclusive. So, only
+# one of the two must be specified below.
+agent:
+    # Type specifies the type of the agent that is being supervised. Internally,
+    # the `type' can be used to auto-discover several attributes if the
+    # supervisor is tailor-made for that agent thereby relieving the user from
+    # having to specify most, if not all, of the configuration.
+    type: io.opentelemetry.collector
+    # Fully-qualified path to the agent executable required for two reasons:
+    # 1. If the supervisor is functioning as a watchdog, then the executable
+    #    is used to start/stop/restart the agent on configuration changes, etc.
+    # 2. If the supervisor is performing the upgrade, the executable indicates
+    #    the file and path in the filesystem that must be replaced with the newer
+    #    version of the executable.
+    executable: /opt/opentelemetry-collector/bin/otel
+    #
+    management:
+        # Dictates how to check if the agent is healthy.
+        healthCheck:
+            url: http://localhost:13133/
+            initialDelay: 5s
+            period: 5s
+            timeout: 20s
+        ownTelemetry:
+            url: http://localhost:8888/
+            initialDelay: 5s
+            period: 5s
+    config:
+        # Currently, only a `file' based configuration is accepted.
+        file: /opt/opentelemetry-collector/config.yaml
+        # If `autoReload` is true, then the agent doesn't need a restart on a config
+        # change as it is internally managed by the agent.
+        autoReload: false
+    # An arbitrary set of key-value pairs that is specific for this agent. This
+    # will be used by the specific supervisor that is managing this agent.
+    attrs:
+        service.name: ecommerce
+        service.namespace: shop
+    # Set of attributes that describe this agent's systemd installation. If this
+    # config element is specified, the `watchdog' config element is ignored as
+    # they are mutually exclusive. The `systemd' information specified here will
+    # be used by the supervisor to restart this agent on configuration changes,
+    # executable upgrades, etc.
+    systemd:
+        name: otel-collector
+    # Watchdog allows the supervisor to monitor the health of the agent and ensure
+    # it is always running (restarting if necessary). In this sense, it acts as
+    # an alternative to agent installations that are not managed by systemd.
+    watchdog:
+        # Set of command-line arguments required to start the `executable` specified
+        # above.
+        args:
+            - --config
+            - /etc/otel/config.yaml
+        # Additional environment variables that must be set when the agent is
+        # started.
+        env:
+            ENV_VAR1: env_value1
+            ENV_VAR2: env_value2
+        # A watchdog policy, like `systemd', albeit not as exhaustive, that
+        # the supervisor uses to control the starting and stopping of the
+        # agents that are being supervised.
+        policy:
+            # Dictates when to restart: `always' restarts any time the supervisor
+            # finds the agent not running; `failure' restarts only if the process
+            # dies as a result of a non-zero exit code (which could be a result of
+            # an internal error or an unexpected OS signal).
+            restart: always
+            # Time to wait before restarting the agent (as configured with `restart')
+            restartWait: 10s
+            # Max attempts the agent is allowed to fail when attempted to START or
+            # STOP in which case the operation will be re-attempted.
+            maxAttempts: 3
+            # Duration to wait between successive attempts of a START or STOP.
+            waitBetweenAttempts: 1s

--- a/supervisor/conf/config-2.yml
+++ b/supervisor/conf/config-2.yml
@@ -1,0 +1,89 @@
+# Connection details for the OpAMP server.
+opampServer:
+    endpoint: https://localhost:1729
+    tls:
+        # Client-side TLS configuration to connect to the OpAMP server.
+
+agents:
+    # Many collector related configuration is omitted in this section as its
+    # tailor-made supervisor can fill in with the defaults.
+    io.opentelemetry.collector:
+        executable: /opt/opentelemetry-collector/bin/otel
+        config:
+            file: /opt/opentelemetry-collector/config.yaml
+        attrs:
+            service.name: ecommerce
+            service.namespace: shop
+        # systemd section is commented -- enable this if the collector is
+        # managed by systemd.
+        # systemd:
+        #    name: otel-collector
+        watchdog:
+            env:
+                ENV_VAR1: env_value1
+                ENV_VAR2: env_value2
+            policy:
+                restart: always
+                restartWait: 10s
+                maxAttempts: 3
+                waitBetweenAttempts: 1s
+    # Many FluentBit related configuration is omitted in this section as its
+    # tailor-made supervisor can fill in with the defaults.
+    io.fluentbit:
+        executable: /opt/fluent-bit/bin/fluent-bit
+        config:
+            file: /opt/fluent-bit/fluent-bit.conf
+            autoReload: true
+        attrs:
+            attr1_key: attr1_value
+        systemd:
+            name: fluentbit
+        # watchdog section is commented -- enable this if fluentbit is NOT
+        # managed by systemd.
+        # watchdog:
+        #     env:
+        #         ENV_VAR1: env_value1
+        #         ENV_VAR2: env_value2
+        #     policy:
+        #         restart: always
+        #         restartWait: 10s
+        #         maxAttempts: 3
+        #         waitBetweenAttempts: 1s
+    # A generic agent for which there is no already implemented supervisor.
+    # In this case, all the configuration elements must be specified for the
+    # supervisor to act correctly.
+    foobar:
+        executable: /opt/foobar/bin/foobar
+        config:
+            file: /opt/foobar/config.yaml
+            autoReload: true
+        attrs:
+             attr1_key: attr1_value
+        management:
+            healthCheck:
+                url: http://localhost:12222/ping
+                initialDelay: 5s
+                period: 5s
+                timeout: 20s
+            ownTelemetry:
+                url: http://localhost:12223/metrics
+                initialDelay: 5s
+                period: 5s
+        systemd:
+            name: foobar-service
+        watchdog:
+            args:
+                - --config
+                - /opt/foobar/config.yaml
+                - --arg1
+                - arg1_value
+                - --arg2
+                - arg2_value
+            env:
+                ENV_VAR1: env_value1
+                ENV_VAR2: env_value2
+            policy:
+                restart: always
+                restartWait: 10s
+                maxAttempts: 3
+                waitBetweenAttempts: 1s

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) AppDynamics, Inc., and its affiliates 2021
+ * All Rights Reserved.
+ * THIS IS UNPUBLISHED PROPRIETARY CODE OF APPDYNAMICS, INC.
+ *
+ * The copyright notice above does not evidence any actual or
+ * intended publication of such source code
+ */
+
+package supervisor
+
+import (
+	"context"
+	"github.com/open-telemetry/opamp-go/supervisor/types"
+)
+
+// Supervisor allows the management of an agent. Specific agents like an
+// OpenTelemetry collector can implement a custom supervisor that understands
+// the internal workings of the collector. Alternatively, a default supervisor
+// allows for the supervision of arbitrary daemon-like processes and provides
+// management options like remote configuration change, agent upgrades,
+// watchdog capabilities, telemetry reporting, etc.
+//
+// The supervisor wraps the client part of the OpAMP protocol and therefore
+// requires an OpAMP server to be running at some endpoint. There is a 1:1
+// mapping between a supervisor and the OpAMP client. A single supervisor
+// executable, however, can run several supervisors within it thereby managing
+// several distinct agent types.
+//
+// See the supervisor sample configuration file and the associated
+// `types.Configuration` for details.
+type Supervisor interface {
+	// Start the supervisor and begin monitoring the associated agent as
+	// specified by the configuration.
+	//
+	// Start MUST return immediately (potentially with an error if the specified
+	// configuration is incorrect or it fails to parse).
+	//
+	// Start, in most cases, should spawn a Go routine to monitor the agent
+	// under supervision.
+	//
+	// Start, on a given instance, must be called exactly once. Subsequent
+	// calls have no effect.
+	Start(config *types.Configuration) error
+
+	// Stop this supervisor and as a result stop monitoring the associated
+	// agent. This method is typically called on receiving an async OS
+	// termination signal like SIGINT or SIGTERM.
+	Stop(ctx context.Context) error
+}

--- a/supervisor/types/config.go
+++ b/supervisor/types/config.go
@@ -1,0 +1,149 @@
+package types
+
+import (
+	"crypto/tls"
+	"time"
+)
+
+// Systemd represents this agent's systemd configuration that is used to
+// restart this agent on configuration changes, executable upgrades, etc.
+// At the minimum, the agent's systemd unit name must be specified so that
+// the supervisor can issue commands like - `systemctl restart otelcol`.
+// This configuration MUST NOT be specified along with the `Watchdog'
+// configuration as they are mutually exclusive.
+type Systemd struct {
+	Name string
+}
+
+// WatchdogPolicy is the policy associated with the lifecycle management
+// of the agent.
+type WatchdogPolicy struct {
+	// Restart indicates the conditions under which the agent must be restarted.
+	// A value of 'always' indicates that the supervisor will always attempt
+	// to restart the agent if it is not running. A value of 'failure' indicates
+	// that the supervisor will restart only if the agent went down as a result
+	// of a failure (non-zero exit code, for example).
+	Restart string
+	// RestartWait is the time to wait before restarting the agent (as configured
+	// with `restart`).
+	RestartWait time.Duration
+	// MaxAttempts is the maximum number of attempts the agent is allowed to
+	// fail a START, STOP or RESTART operation.
+	MaxAttempts int
+	// WaitBetweenAttempts is the duration to wait between successive attempts
+	// to START, STOP or RESTART the agent.
+	WaitBetweenAttempts time.Duration
+}
+
+// HealthCheck is the configuration that allows the supervisor to check the
+// health status of the agent.
+type HealthCheck struct {
+	// Url is the url at which the agent reports its health status.
+	Url          string
+	// InitialDelay is the delay that must be observed before the first request
+	// can be issued.
+	InitialDelay time.Duration
+	// Period is the interval at which the health status must be probed.
+	Period       time.Duration
+	// Timeout is the duration at which the supervisor concludes that the agent
+	// is no longer healthy (due to successive failures in reaching the specified
+	// URL).
+	Timeout      time.Duration
+}
+
+// OwnTelemetry is the configuration that allows the supervisor to scrape the
+// agent for its own telemetry.
+type OwnTelemetry struct {
+	// The URL where metrics can be scraped.
+	Url          string
+	// The initial delay that must be observed before the first request can
+	// be issued.
+	InitialDelay time.Duration
+	// The interval at which the metrics should be scraped.
+	Period       time.Duration
+}
+
+// Management represents a set of endpoints (currently, http) that are uesd
+// to perform health-check on the agent, obtain the agent's own telemetry,
+// etc.
+type Management struct {
+	// HealthCheck defines the specification for doing periodic health-checks
+	// on the agent. OpenTelemetry, for example, by default reports the status
+	// on the `:13133` port.
+	HealthCheck  *HealthCheck
+	// OwnTelemetry defines the specification for scraping agent's own telemetry
+	// to report to a OTLP backend. In OpenTelemetry collector, the `:8888`
+	// port, by default, allows scraping for prometheus.
+	OwnTelemetry *OwnTelemetry
+}
+
+// Watchdog allows the supervisor to monitor the health of the agent in
+// the absence of a `Systemd' installation of the agent. It also enables
+// the supervisor to restart the agent during configuration changes and
+// upgrades.
+type Watchdog struct {
+	// Args are the additional command-line arguments supplied to the executable.
+	Args []string
+	// Env is any additional environment variables that must be passed to the
+	// agent process.
+	Env map[string]string
+	// Policy is this agent's watchdog policy.
+	Policy *WatchdogPolicy
+}
+
+// AgentConfig represents this agent's configuration details: the location of
+// the configuration file, for example, that must be updated on a remote
+// configuration change.
+type AgentConfig struct {
+	// File is the path to the configuration file corresponding to the agent.
+	File string
+	// AutoReload, if true, indicates that the agent does not require a restart
+	// on configuration change.
+	AutoReload bool
+}
+
+// Agent specifies the agent managed by this supervisor. Concretely, it dictates
+// where to find the agent, how to start it and its configuration file. This
+// basic information is necessary for the supervisor to restart the agent, for
+// example, on a remote configuration change.
+type Agent struct {
+	// Type represents the type of this agent. For example, `otelcol' can be
+	// a valid agent type. Internally, the `type' can be used to construct
+	// a purpose-built supervisor rather than a generic one. For example, a
+	// `otelcol' agent type can construct a supervisor that can manage an
+	// OpenTelemetry collector.
+	Type string
+	// Executable is the path to the agent's executable. For example, `/otel'
+	// or `/fluent-bit/bin/fluent-bit'
+	Executable string
+	// Attrs are an arbitrary collection of key-value pairs that is specific
+	// for this agent. An OTEL-collector, for example, can specify the
+	// `service.name' and `service.namespace' as attributes that can be used
+	// to identify this collector with the OpAMP server.
+	Attrs map[string]string
+	// Config is this agent's configuration. See `AgentConfig' for additional
+	// details.
+	Config *AgentConfig
+	// Systemd is this agent's systemd configuration. This MUST NOT be
+	// specified in conjunction with the `Watchdog' configuration.
+	Systemd *Systemd
+	// Watchdog is this agent's watchdog configuration. This MUST NOT be
+	// specified in conjunction with the `Systemd' configuration.
+	Watchdog *Watchdog
+}
+
+// OpAMPServerConfig contains the connection details to talk to the OpAMP
+// Server.
+type OpAMPServerConfig struct {
+	// Endpoint is the URL of the OpAMP server on which a WebSocket connection
+	// is established to exchange OpAMP messages.
+	Endpoint string
+	// Tls contains the configuration required for client-side SSL/TLS encryption.
+	Tls *tls.Config
+}
+
+// Configuration is the supervisor's configuration.
+type Configuration struct {
+	OpAMPServer *OpAMPServerConfig
+	Agent       *Agent
+}


### PR DESCRIPTION
This changeset takes a first stab at the supervisor model for
implementing the client side of the OpAMP protocol.

There are two parts to this changeset:

1. Proposal on the supervisor configuration file based on the draft
specification. Two alternate configuration files are provided as an
example of how the supervisor might be instantiated.

2. A simple supervisor interface that all implementations should adhere
to. This allows for the implementation of a generic supervisor as well
as tailor-made ones that has an understanding of the inner workings of
the agent that it is supervising. The supervisor internally wraps the
OpAMP client that communicates with the OpAMP server for management
instructions.