### PR TITLE
Initial stab at OpAMP-based supervisor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect

--- a/supervisor/agent/agent.go
+++ b/supervisor/agent/agent.go
@@ -1,0 +1,55 @@
+package agent
+
+import "github.com/open-telemetry/opamp-go/protobufs"
+
+type Settings struct {
+	// Attrs are any key-value pair that describes the identifying and
+	// non-identifying attributes of the agent.
+	Attrs map[string]string `koanf:"attrs"`
+
+	// ConfigSpec describes this agent's configuration source from which
+	// its effective configuration is read and to which the remote configuration
+	// is written.
+	ConfigSpec *ConfigSpec `koanf:"config"`
+
+	// CommandConfig describes how to start, stop and restart this agent.
+	CommandConfig *CommandConfig `koanf:"command"`
+}
+
+// IdentityProvider provides this agent's unique identification.
+type IdentityProvider interface {
+	// Type returns the FQDN of this agent. For example, for an OpenTelemetry
+	// Collector this should return "io.opentelemetry.collector".
+	Type() string
+
+	// Version returns this agent's build version.
+	//
+	// Version may return an error if it is unable to determine the Agent's
+	// version. This is possible, for example, if the only way to retrieve
+	// the agent's version is to make an HTTP request and the request fails.
+	Version() (string, error)
+
+	// Namespace return this agent's namespace. For example, for an OpenTelemetry
+	// Collector, this is equivalent to `service.namespace'.
+	Namespace() string
+}
+
+// Agent represents a long running process that allows for management via a
+// supervisor. OpenTelemetry Collector or a FluentBit daemon are some of the
+// examples of an Agent.
+type Agent interface {
+	// Initialize this agent with the provided settings.
+	// TODO: this could also be done in the constructor of the concrete implementation.
+	Initialize(settings *Settings)
+
+	// Commander allows the agent to be started, stopped and restarted.
+	Commander
+
+	// IdentityProvider allows several identifying attributes like the Agent's
+	// type, version and namespace to be returned.
+	IdentityProvider
+
+	// GetOtherAttributes returns attributes that do not necessarily help
+	// identify the agent, but describe where it runs.
+	GetOtherAttributes() ([]*protobufs.KeyValue, error)
+}

--- a/supervisor/agent/agent_impl.go
+++ b/supervisor/agent/agent_impl.go
@@ -1,0 +1,5 @@
+package agent
+
+func New(settings *Settings) Agent {
+	return nil
+}

--- a/supervisor/agent/commander.go
+++ b/supervisor/agent/commander.go
@@ -1,0 +1,133 @@
+package agent
+
+import "context"
+
+// ExecConfig describes how to start, stop and restart the Agent.
+type ExecConfig struct {
+	// Name is the path to the Agent executable. Path can be relative
+	// or absolute. A relative path should be relative to the CWD of the
+	// supervisor.
+	Name string `koanf:"name"`
+	// Args are the set of command-line arguments that must be specified along
+	// with the executable to start the Agent.
+	Args []string `koanf:"args"`
+}
+
+// SystemdConfig describes the systemd installation of the Agent.
+type SystemdConfig struct {
+	// Name is the name of the systemd unit name with which the Agent is
+	// referred in the systemd namespace.
+	Name string `koanf:"name"`
+}
+
+// CommandConfig describes a systemd-based or an exec-based way of starting,
+// stopping and restarting the agent. Only one of `ExecConfig' or `SystemdConfig'
+// must be specified.
+type CommandConfig struct {
+	ExecConfig    *ExecConfig    `koanf:"exec"`
+	SystemdConfig *SystemdConfig `koanf:"systemd"`
+}
+
+// Process represents information related to a running agent process.
+type Process struct {
+
+	// ID is the id of the agent process that is currently running. Currently,
+	// this is relevant only when the agent process is exec'd in which case
+	// this represents the PID of the agent process.
+	//
+	// The ID is of type string to allow, for instance, a docker container
+	// containing the agent to be launched.
+	//
+	// A watchdog may use this ID to later stop this agent process.
+	//
+	// If the agent process was started as a `systemd' facility, this field
+	// need not be set.
+	// TODO: maybe this is an overkill -- we should start with just a PID?
+	ID string
+
+	// Done is the channel in which the process termination event is sent.
+	//
+	// A watchdog, for instance, can wait on this channel to listen to process
+	// termination event.
+	//
+	// If the agent process was started as a `systemd' facility, the channel
+	// maybe nil as the supervisor does not control the agent process other
+	// than launching the `systemctl start otel-collector`.
+	Done <-chan struct{}
+}
+
+// Restarter provides the ability to restart this Agent. This interface
+// allows for helpers that allow the agent to be restarted based on whether
+// or not the watcher is configured.
+type Restarter interface {
+	// Restart this Agent.
+	Restart(ctx context.Context) error
+}
+
+// Commander enables the agent to be started, stopped and restarted at various
+// points in time. It also checks if the agent is running and whether or not
+// it is healthy.
+type Commander interface {
+	// Start the agent process and return the `Process' information. The
+	// actual mechanism for starting the process depends on whether or not
+	// the agent is managed by a `systemd'-like facility.
+	//
+	// Start MUST NOT block and return whether or not it was able to successfully
+	// launch the agent process from an OS perspective, i.e., the process may
+	// start but fail sometime later.
+	//
+	// Start returns the process information pertaining to the new agent process
+	// or an error if the process could not be successfully restarted.
+	Start() (*Process, error)
+
+	// IsRunning returns whether or not the agent, as defined by `process' is
+	// running. This check returns the truth value of the agent's running status
+	// as seen by the OS. For example, on a *nix systems, this is equivalent to
+	// `kill -0' returning successful.
+	IsRunning(process *Process) (bool, error)
+
+	// IsHealthy returns whether or not the agent, as defined by `healthCheck'
+	// is healthy. This check returns the truth value of the agent's health
+	// status as defined by the health check configuration. For example, for
+	// an Open Telemetry collector, this is equivalent to a `GET http://localhost:13133/'
+	// returning a `200 OK'.
+	IsHealthy( /* TODO */) (bool, error)
+
+	// Stop the agent process as defined by `process'. The actual mechanism
+	// for stopping the process depends on whether or not the agent is managed
+	// by a `systemd'-like facility.
+	//
+	// Stop MUST wait for the process to be terminated from an OS perspective,
+	// i.e., it should wait until `Running' returns false. TODO (restrictive?)
+	//
+	// Stop MUST honor the passed in context and return with an error if the
+	// deadline expires.
+	Stop(ctx context.Context, process *Process) error
+
+	// Restart the agent process as defined by `process'. The actual mechanism
+	// for stopping the process depends on whether or not the agent is managed
+	// by a `systemd'-like facility.
+	//
+	// In a non-systemd environment, Restart, most likely, is implemented as
+	// a Stop followed by a Start in which case the Stop part might block until
+	// the process terminates.
+	//
+	// Restart MUST honor the passed in context and return with an error if
+	// the deadline expires.
+	//
+	// Restart returns the process information pertaining to the new agent process
+	// or an error if the process could not be successfully restarted.
+	Restart(
+		ctx context.Context,
+		process *Process,
+	) (*Process, error)
+}
+
+// NewCommander creates a commander, systemd or exec based, that can start,
+// stop, restart the agent among other things.
+func NewCommander(config *CommandConfig) Commander {
+	if config.ExecConfig != nil {
+		return &execCommander{config: config.ExecConfig}
+	}
+	return &systemdCommander{config: config.SystemdConfig}
+}

--- a/supervisor/agent/commander_exec.go
+++ b/supervisor/agent/commander_exec.go
@@ -1,0 +1,29 @@
+package agent
+
+import (
+	"context"
+)
+
+type execCommander struct {
+	config *ExecConfig
+}
+
+func (e execCommander) Start() (*Process, error) {
+	panic("implement me")
+}
+
+func (e execCommander) IsRunning(process *Process) (bool, error) {
+	panic("implement me")
+}
+
+func (e execCommander) IsHealthy() (bool, error) {
+	panic("implement me")
+}
+
+func (e execCommander) Stop(ctx context.Context, process *Process) error {
+	panic("implement me")
+}
+
+func (e execCommander) Restart(ctx context.Context, process *Process) (*Process, error) {
+	panic("implement me")
+}

--- a/supervisor/agent/commander_systemd.go
+++ b/supervisor/agent/commander_systemd.go
@@ -1,0 +1,30 @@
+package agent
+
+import (
+	"context"
+)
+
+type systemdCommander struct {
+	config *SystemdConfig
+}
+
+func (s systemdCommander) Start() (*Process, error) {
+	panic("implement me")
+}
+
+func (s systemdCommander) IsRunning(process *Process) (bool, error) {
+	panic("implement me")
+}
+
+func (s systemdCommander) IsHealthy() (bool, error) {
+	panic("implement me")
+}
+
+func (s systemdCommander) Stop(ctx context.Context, process *Process) error {
+	panic("implement me")
+}
+
+func (s systemdCommander) Restart(ctx context.Context, process *Process) (*Process, error) {
+	panic("implement me")
+}
+

--- a/supervisor/agent/configurer.go
+++ b/supervisor/agent/configurer.go
@@ -1,0 +1,55 @@
+package agent
+
+import (
+	"context"
+	"github.com/open-telemetry/opamp-go/protobufs"
+)
+
+// ConfigSpec describes the location of the this Agent's configuration.
+// Currently, only a file-based configuration is allowed on which the
+// local-read and remote-write are performed.
+// TODO: I think we can expand on this idea to provide a separate read
+// and write specification which can be file or network based. See the
+// alternate configuration in the sample yaml.
+type ConfigSpec struct {
+	// File is the path to this Agent's configuration file.
+	File string `koanf:"file"`
+
+	// AutoReload is true if this agent must be restarted on configuration
+	// change and false otherwise.
+	AutoReload bool `koanf:"auto_reload"`
+}
+
+// Configurer allows the Agent's effective configuration to be fetched and
+// updated.
+type Configurer interface {
+	// LoadEffectiveConfig loads this Agent's effective configuration.
+	//
+	// Effective configuration is obtained by merging the configuration elements
+	// from various sources known to this agent. Typically, the effective
+	// configuration, in most cases, is just loaded from the Agent's local
+	// configuration file.
+	LoadEffectiveConfig(configSpec *ConfigSpec) (*protobufs.EffectiveConfig, error)
+
+	// UpdateConfig updates this agent's configuration with the specified
+	// remote configuration.
+	//
+	// UpdateConfig MUST restart the agent if `auto_reload' is true for this
+	// agent.
+	//
+	// UpdateConfig, on restarting an agent after configuration update, MUST
+	// wait for the agent to become healthy before returning successfully.
+	// The provided `Restarter' can be used to restart the agent as needed.
+	//
+	// If the agent remains unhealthy after the update, the agent must be
+	// reverted to the previously known configuration.
+	//
+	// UpdateConfig returns the effective configuration after successfully
+	// applying the remote configuration.
+	UpdateConfig(
+		ctx context.Context,
+		configSpec *ConfigSpec,
+		remoteConfig *protobufs.AgentRemoteConfig,
+		restarter Restarter,
+	) (*protobufs.EffectiveConfig, error)
+}

--- a/supervisor/agent/configurer_impl.go
+++ b/supervisor/agent/configurer_impl.go
@@ -1,0 +1,32 @@
+package agent
+
+import (
+	"context"
+	"github.com/open-telemetry/opamp-go/protobufs"
+)
+
+type configurer struct {
+}
+
+func (c configurer) LoadEffectiveConfig(
+	configSpec *ConfigSpec,
+) (*protobufs.EffectiveConfig, error) {
+
+	panic("implement me")
+}
+
+func (c configurer) UpdateConfig(
+	ctx context.Context,
+	configSpec *ConfigSpec,
+	remoteConfig *protobufs.AgentRemoteConfig,
+	restarter Restarter,
+) (*protobufs.EffectiveConfig, error) {
+
+	panic("implement me")
+}
+
+// NewConfigurer creates a configuration manager that can read and write
+// agent configuration.
+func NewConfigurer() Configurer {
+	return &configurer{}
+}

--- a/supervisor/agent/healthchecker.go
+++ b/supervisor/agent/healthchecker.go
@@ -1,0 +1,3 @@
+package agent
+
+

--- a/supervisor/agent/watcher.go
+++ b/supervisor/agent/watcher.go
@@ -1,0 +1,54 @@
+package agent
+
+import (
+	"context"
+	"time"
+)
+
+// WatchConfig dictates the timing restrictions to be honored during an attempt
+// to start, stop or restart the agent.
+// restart the agent.
+type WatchConfig struct {
+	// MaxAttempts is the maximum number of attempts the agent is allowed to
+	// fail a START, STOP or RESTART operation.
+	MaxAttempts int `koanf:"max_attempts"`
+
+	// WaitBetweenAttempts is the duration to wait between successive attempts
+	// to START, STOP or RESTART the agent.
+	WaitBetweenAttempts time.Duration `koanf:"wait_between_attempts"`
+}
+
+// Watcher monitors the health of the agent. Health, in this context, is only
+// as seen from the OS perspective, i.e., whether or not the agent process
+// is alive or not.
+type Watcher interface {
+	// Watch begins the monitoring of the agent's health.
+	//
+	// Watch MUST honor the provided context and return as soon as the agent
+	// process has started. Any long running logic (agent monitoring) must be
+	// done in a separate Go routine.
+	//
+	// Watch returns an error if the agent cannot be started per the specified
+	// configuration.
+	//
+	// Watch should only be called once (preferably at the start of the
+	// supervisor).
+	Watch(ctx context.Context) error
+
+	// RestartAgent restarts the monitored agent. It allows a supervisor to
+	// restart the agent on a configuration or package update.
+	//
+	// RestartAgent MUST honor the provided context and return as soon as the
+	// agent is restarted (waiting until the process becomes alive).
+	//
+	// RestartAgent returns an error if the agent cannot be restarted.
+	RestartAgent(ctx context.Context) error
+
+	// Stop the agent along with the monitoring of the its health.
+	//
+	// Stop MUST honor the provided context and return as soon as the agent
+	// is terminated.
+	//
+	// Stop returns an error if the watcher could not be stopped.
+	Stop(ctx context.Context) error
+}

--- a/supervisor/agent/watcher_impl.go
+++ b/supervisor/agent/watcher_impl.go
@@ -1,0 +1,30 @@
+package agent
+
+import (
+	"context"
+)
+
+type watcher struct {
+	commander Commander
+	config    *WatchConfig
+}
+
+func (watcher) Watch(ctx context.Context) error {
+	panic("implement me")
+}
+
+func (watcher) RestartAgent(ctx context.Context) error {
+	panic("implement me")
+}
+
+func (watcher) Stop(ctx context.Context) error {
+	panic("implement me")
+}
+
+// NewWatcher creates a watcher that monitors the health of the agent.
+func NewWatcher(commander Commander, config *WatchConfig) Watcher {
+	return &watcher{
+		commander: commander,
+		config:    config,
+	}
+}

--- a/supervisor/callbacks.go
+++ b/supervisor/callbacks.go
@@ -1,0 +1,68 @@
+package supervisor
+
+import (
+	"context"
+	"github.com/open-telemetry/opamp-go/client/types"
+	"github.com/open-telemetry/opamp-go/protobufs"
+)
+
+var _ types.Callbacks = (*supervisor)(nil)
+
+func (s *supervisor) OnConnect() {
+	s.logger.Debugf("Connected to the server")
+}
+
+func (s supervisor) OnConnectFailed(err error) {
+	s.logger.Errorf("Failed to connect to the server: %v", err)
+}
+
+func (s supervisor) OnError(err *protobufs.ServerErrorResponse) {
+	s.logger.Errorf("Server returned an error response: %v", err.ErrorMessage)
+}
+
+func (s supervisor) OnRemoteConfig(
+	ctx context.Context, remoteConfig *protobufs.AgentRemoteConfig,
+) (*protobufs.EffectiveConfig, error) {
+	return s.configurer.UpdateConfig(
+		ctx,
+		s.config.AgentSettings.ConfigSpec,
+		remoteConfig,
+		nil)
+}
+
+func (s supervisor) OnOpampConnectionSettings(
+	ctx context.Context, settings *protobufs.ConnectionSettings,
+) error {
+	panic("unimplemented")
+}
+
+func (s supervisor) OnOpampConnectionSettingsAccepted(settings *protobufs.ConnectionSettings) {
+	panic("unimplemented")
+}
+
+func (s supervisor) OnOwnTelemetryConnectionSettings(
+	ctx context.Context, telemetryType types.OwnTelemetryType,
+	settings *protobufs.ConnectionSettings,
+) error {
+	panic("unimplemented")
+}
+
+func (s supervisor) OnOtherConnectionSettings(
+	ctx context.Context, name string, settings *protobufs.ConnectionSettings,
+) error {
+	panic("unimplemented")
+}
+
+func (s supervisor) OnAddonsAvailable(
+	ctx context.Context,
+	addons *protobufs.AddonsAvailable,
+	syncer types.AddonSyncer,
+) error {
+	panic("unimplemented")
+}
+
+func (s supervisor) OnAgentPackageAvailable(
+	addons *protobufs.AgentPackageAvailable, syncer types.AgentPackageSyncer,
+) error {
+	panic("unimplemented")
+}

--- a/supervisor/cmd/main.go
+++ b/supervisor/cmd/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"flag"
+	"github.com/open-telemetry/opamp-go/supervisor"
+	"log"
+	"os"
+)
+
+func main() {
+	var configFile string
+	flag.StringVar(&configFile, "c", "", "Supervisor configuration file")
+	flag.Parse()
+
+	logger := &supervisor.Logger{Logger: log.Default()}
+	if err := supervisor.New(configFile, logger).Start(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/supervisor/config.go
+++ b/supervisor/config.go
@@ -1,0 +1,85 @@
+package supervisor
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"github.com/knadh/koanf"
+	"github.com/knadh/koanf/parsers/yaml"
+	"github.com/knadh/koanf/providers/file"
+	"github.com/open-telemetry/opamp-go/supervisor/agent"
+)
+
+// TLSConfig describes basic client-side certificates to be used during
+// client-side TLS authentication.
+// TODO: these are just to fill in the gaps; not a lot of thought put into it.
+type TLSConfig struct {
+	// CertFile is the path to the client-side PEM-encoded file.
+	CertFile string
+	// KeyFile is the path to the key-file corresponding to the PEM file.
+	KeyFile string
+	// See tls.Config#InsecureSkipVerify.
+	InsecureSkipVerify bool
+}
+
+func (t *TLSConfig) loadTLSConfig() (*tls.Config, error) {
+	cert, err := tls.LoadX509KeyPair(t.CertFile, t.KeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load %q with %q", t.CertFile, t.KeyFile)
+	}
+	return &tls.Config{
+		Certificates:       []tls.Certificate{cert},
+		InsecureSkipVerify: t.InsecureSkipVerify,
+	}, nil
+}
+
+// OpAMPServer describes how to connect to an OpAMP server.
+type OpAMPServer struct {
+	Endpoint  string     `kaonf:"endpoint"`
+	TLSConfig *TLSConfig `koanf:"tls_config"`
+}
+
+// Configuration describes this supervisor's configuration along with the
+// Agent that it supervises.
+type Configuration struct {
+	OpAMPServer *OpAMPServer `koanf:"server"`
+
+	AgentSettings *agent.Settings `koanf:"agent"`
+
+	// WatchConfig describes the configuration that is used to monitor the
+	// health of the agent.
+	// TODO: the watchdog is not part of the agent configuration as it wraps
+	// the agent and monitors it. It could also be part of the agent configuration
+	WatchConfig *agent.WatchConfig `kaonf:"watchdog"`
+}
+
+// Load the supervisor configuration.
+func (s *supervisor) loadConfig() (*Configuration, error) {
+	k := koanf.New(".")
+	if err := k.Load(file.Provider(s.configFile), yaml.Parser()); err != nil {
+		return nil, fmt.Errorf("failed to read supervisor configuration: %w", err)
+	}
+
+	var config Configuration
+	if err := k.Unmarshal("", &config); err != nil {
+		return nil, fmt.Errorf("failed to parse supervisor configuration: %w", err)
+	}
+
+	if s.config.OpAMPServer == nil {
+		return nil, errors.New("'server' section missing")
+	}
+
+	if s.config.AgentSettings == nil {
+		return nil, errors.New("'agent' section missing")
+	}
+
+	if s.config.OpAMPServer.TLSConfig != nil {
+		tc, err := s.config.OpAMPServer.TLSConfig.loadTLSConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed to load TLS configuration: %w", err)
+		}
+		s.tls = tc
+	}
+
+	return &config, nil
+}

--- a/supervisor/config/config_sample.yaml
+++ b/supervisor/config/config_sample.yaml
@@ -1,0 +1,67 @@
+# Connection details for the OpAMP server.
+server:
+    endpoint: wss://localhost:1729
+    #    tls:
+    # Client-side TLS configuration to connect to the OpAMP server.
+
+agent:
+    # Describes the configuration properties of the agent.
+    config:
+        # Currently, only a `file' based configuration is accepted.
+        file: /opt/opentelemetry-collector/config.yaml
+        # If `auto_reload` is true, then the agent doesn't need a restart on a config
+        # change as it is internally managed by the agent.
+        auto_reload: false
+
+    # TODO: another way of specifying configuration that allows configuration
+    # to be fetched and updated via network call.
+    config_alt:
+        read:
+            # source: file:/opt/opentelemetry-collector/config.yaml
+            source: http://localhost:1010/config # GET
+            content_type: application/yaml
+        write:
+            # dest: file:/opt/opentelemetry-collector/config.yaml
+            dest: http://localhost:1010/config # PUT
+            content_type: application/yaml
+        auto_reload: false
+
+    # Dictates how to check if the agent is healthy.
+    health_check:
+        url: http://localhost:13133/
+        initial_delay: 5s
+        period: 5s
+        timeout: 20s
+
+    # An arbitrary set of key-value pairs that identify this agent and may
+    # describe where this agent runs.
+    attrs:
+        -   service.name: io.opentelemetry.collector
+        -   service.namespace: collector
+        -   other_attr1: other_attr1_val
+        -   other_attr2: other_attr2_val
+
+    command:
+        # systemd:
+        #     name: ot-collector
+        exec:
+            name: /opt/opentelemetry-collector/bin/otel
+            # Set of command-line arguments required to start the `executable` specified
+            # above.
+            args:
+                - --config
+                - /etc/otel/config.yaml
+
+# Watchdog allows the supervisor to monitor the health of the agent and ensure
+# it is always running (restarting if necessary). In this sense, it acts as
+# an alternative to agent installations that are not managed by systemd.
+#
+# A watchdog policy, like `systemd', albeit not as exhaustive, allows the
+# watchdog to honor certain timing restrictions during the start, stop and
+# restart of the agents.
+watchdog:
+    # Max attempts the agent is allowed to fail when attempted to START or
+    # STOP in which case the operation will be re-attempted.
+    max_attempts: 3
+    # Duration to wait between successive attempts of a START or STOP.
+    wait_between_attempts: 1s

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -1,0 +1,86 @@
+package supervisor
+
+import (
+	"crypto/tls"
+	"fmt"
+	"github.com/oklog/ulid/v2"
+	"github.com/open-telemetry/opamp-go/client"
+	"github.com/open-telemetry/opamp-go/supervisor/agent"
+	"log"
+	"math/rand"
+	"time"
+)
+
+type Logger struct {
+	Logger *log.Logger
+}
+
+func (l *Logger) Debugf(format string, v ...interface{}) {
+	l.Logger.Printf(format, v...)
+}
+
+func (l *Logger) Errorf(format string, v ...interface{}) {
+	l.Logger.Printf(format, v...)
+}
+
+type supervisor struct {
+	logger *Logger
+
+	configFile string
+	config     *Configuration
+	tls        *tls.Config
+
+	instanceID string
+
+	client client.OpAMPClient
+
+	agent      agent.Agent
+	watcher    agent.Watcher
+	configurer agent.Configurer
+}
+
+// New creates a new supervisor based on the provided configuration.
+func New(configFile string, logger *Logger) *supervisor {
+	entropy := ulid.Monotonic(rand.New(rand.NewSource(0)), 0)
+	return &supervisor{
+		configFile: configFile,
+		client:     client.New(logger),
+		instanceID: ulid.MustNew(ulid.Timestamp(time.Now()), entropy).String(),
+	}
+}
+
+func (s *supervisor) createAndStartAgent() error {
+	panic("implement me")
+	//s.agent = agent.New(s.config.AgentSettings)
+	//agent.NewWatcher(s.agent, s.config.WatchConfig)
+}
+
+func (s *supervisor) createAndStartClient() error {
+	settings := client.StartSettings{
+		OpAMPServerURL: s.config.OpAMPServer.Endpoint,
+		TLSConfig:      s.tls,
+		InstanceUid:    s.instanceID,
+	}
+
+	return s.client.Start(settings)
+}
+
+func (s *supervisor) Start() error {
+	// Load the supervisor configuration.
+	config, err := s.loadConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load supervisor configuration: %w", err)
+	}
+	s.config = config
+
+	if err := s.createAndStartAgent(); err != nil {
+		return fmt.Errorf("failed to start the agent: %w", err)
+	}
+
+	if err := s.createAndStartClient(); err != nil {
+		return fmt.Errorf("failed to start the client: %w", err)
+	}
+
+	// TODO: listen on SIGTERM/SIGINT and stop everything
+	return nil
+}


### PR DESCRIPTION
This changeset attempts several things:

1. It defines several interfaces that describe an agent and how several
optional functionalities like watchdog, remote configuration, etc can be
implemented and wired.

2. It implements a very basic supervisor stub to load the configuration,
initialize the client and agent.